### PR TITLE
Configure via CLI arguments.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,9 @@ authors = ["Karsten Jeschkies <k@jeschkies.xyz>"]
 edition = "2018"
 
 [dependencies]
+env_logger = "0.6"
+log = "0.4"
 jsonwebtoken = "6"
 reqwest = "0.9"
 serde = { version = "1.0", features = ["derive"] }
-
+structopt = "0.2"

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 
 ## Usage
 
-Simply start the daemon with `authd [PRIVATE KEY] [TOKEN LOCATION]`. The program will fetch a new authentication token
-and save it to `TOKEN LOCATION`. Delete the token if you want to force a refresh.
+Simply start the daemon with `authd <private_key> <token>`. The program will fetch a new authentication token
+and save it to `token`. Delete the token if you want to force a refresh.
 
 You client should read the toke form the token file and wait if there is no file yet.
 
@@ -12,3 +12,5 @@ You client should read the toke form the token file and wait if there is no file
 
 * `--cert` Optional location of a CA certificate file for SSL connections. It defaults to `.ssl/ca-bundle.crt`.
 * `--endpoint` The authentication endpoint to use. It defaults to `https://master.mesos`.
+
+The program uses [env_logger](https://github.com/sebasmagri/env_logger). You can set the log level via `RUST_LOG=info`.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You client should read the toke form the token file and wait if there is no file
 
 ## Options
 
-* `--cert` Optional location of a CA certificate file for SSL connections. It defaults to `.ssl/ca-bundle.crt`.
+* `--cert` Optional location of a CA certificate file for SSL connections. Eg on a DC/OS strict cluster it should be `.ssl/ca-bundle.crt`.
 * `--endpoint` The authentication endpoint to use. It defaults to `https://master.mesos`.
 
 The program uses [env_logger](https://github.com/sebasmagri/env_logger). You can set the log level via `RUST_LOG=info`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let uri = format!("{}/acs/api/v1/auth/login", opts.endpoint);
     let cert = load_custom_certificate(opts.cert)?;
 
-    let client = Client::builder().add_root_certificate(cert).build()?;
+    let mut client = Client::builder();
+
+    if let Some(ref p) = opts.cert {
+        let cert = load_custom_certificate(p)?;
+        client = client.add_root_certificate(cert);
+    };
+
+    let client = client.build()?;
 
     // load secret
     let mut secret = Vec::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,7 @@ struct Opt {
 
     #[structopt(long, default_value = ".ssl/ca-bundle.crt", parse(from_os_str))]
     /// Path to a custom certificate for securing HTTP connections.
-    cert: PathBuf,
+    cert: Option<PathBuf>,
 
     #[structopt(long, default_value = "https://master.mesos")]
     /// Authentication endpoint to use.

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,13 +2,17 @@ mod error;
 
 use crate::error::Error;
 
+use env_logger;
+use log::info;
 use jsonwebtoken::{encode, Algorithm, Header};
 use reqwest::{Certificate, Client, Request};
 use serde::{Deserialize, Serialize};
 use std::fs::File;
+use std::io::prelude::*;
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
+use structopt::StructOpt;
 
 /// A JWT Claim.
 ///
@@ -73,20 +77,47 @@ fn load_custom_certificate<P: AsRef<Path>>(path: P) -> Result<Certificate, Error
     Ok(cert)
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let uri = "https://kjeschkie-elasticl-56l539m0xkcm-551146504.us-west-2.elb.amazonaws.com/acs/api/v1/auth/login";
 
-    let cert = load_custom_certificate("dcos-ca.crt")?;
+#[derive(Debug, StructOpt)]
+#[structopt(name = "authd", about = "An authentication daemon.")]
+struct Opt {
+
+    #[structopt(long, default_value = ".ssl/ca-bundle.crt", parse(from_os_str))]
+    /// Path to a custom certificate for securing HTTP connections.
+    cert: PathBuf,
+
+    #[structopt(long, default_value = "https://master.mesos")]
+    /// Authentication endpoint to use.
+    endpoint: String,
+
+    #[structopt(parse(from_os_str))]
+    /// Path to private RSA key in DER format.
+    private_key: PathBuf,
+
+    #[structopt(parse(from_os_str))]
+    /// Target path for authentication token.
+    token: PathBuf,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    let opts = Opt::from_args();
+    let uri = format!("{}/acs/api/v1/auth/login", opts.endpoint);
+    let cert = load_custom_certificate(opts.cert)?;
 
     let client = Client::builder().add_root_certificate(cert).build()?;
 
     // load secret
     let mut secret = Vec::new();
-    File::open("usi.private.der")?.read_to_end(&mut secret)?;
-    let login_request = login_request(&client, uri, &secret)?;
+    File::open(opts.private_key)?.read_to_end(&mut secret)?;
+    let login_request = login_request(&client, &uri, &secret)?;
 
     let body: AuthenticationToken = client.execute(login_request)?.json()?;
 
-    println!("body = {:?}", body);
+    // write token to file
+    File::create(opts.token)?.write_all(body.token.as_bytes())?;
+
+    info!("body = {:?}", body);
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,7 @@ fn load_custom_certificate<P: AsRef<Path>>(path: P) -> Result<Certificate, Error
 #[structopt(name = "authd", about = "An authentication daemon.")]
 struct Opt {
 
-    #[structopt(long, default_value = ".ssl/ca-bundle.crt", parse(from_os_str))]
+    #[structopt(long, parse(from_os_str))]
     /// Path to a custom certificate for securing HTTP connections.
     cert: Option<PathBuf>,
 
@@ -104,7 +104,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let opts = Opt::from_args();
     let uri = format!("{}/acs/api/v1/auth/login", opts.endpoint);
-    let cert = load_custom_certificate(opts.cert)?;
 
     let mut client = Client::builder();
 


### PR DESCRIPTION
This patch introduces command line argument parsing via Structopt and
saves the token to a file. Call `cargo run -- --help` to see all
options.

Full example:

```
RUST_LOG=info cargo run -- \
	usi.private.der \
	token.txt \
        --endpoint https://dcos.com/ \
	--cert dcos-ca.crt
```

Resolves #3 and resolves #2.