### PR TITLE
Refresh token once it expired.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Karsten Jeschkies <k@jeschkies.xyz>"]
 edition = "2018"
 
 [dependencies]
+chrono = { version = "0.4", features = ["serde"] }
 env_logger = "0.6"
 log = "0.4"
 jsonwebtoken = "6"


### PR DESCRIPTION
This introduces a simple event loop that
* refreshes the authentication token if it is `None`
* sets the token to `None` once it expired.

Resolves #5