### PR TITLE
Refresh auth token when it expired.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
+crossbeam-channel = "0.3.8"
 env_logger = "0.6"
 log = "0.4"
 jsonwebtoken = "6"

--- a/src/authd.rs
+++ b/src/authd.rs
@@ -62,8 +62,8 @@ impl Authd {
         Ok(())
     }
 
+    /// Pre-mortem: Set a token expiration to trigger a refresh.
     fn set_token_expiration_timer(&mut self) -> Result<(), Error> {
-        // Pre-mortem: Nullify authentication token and trigger refresh if it expired.
         if let Some(ref token) = self.auth_token {
             let AuthenticationClaim { exp } = token.claim()?;
             match (exp - Utc::now()).to_std() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -118,6 +118,8 @@ struct LoginRequestBody {
     token: String,
 }
 
+// TODO: this is verify similar to AuthenticationClaim. Maybe they should be the same.
+
 /// A JWT Claim.
 ///
 /// * `uid` - The service user id.


### PR DESCRIPTION
This uses the Crossbeam channel and select to trigger the refresh of the
token.